### PR TITLE
Casts headers to object

### DIFF
--- a/src/StandardPayloadBuilder.php
+++ b/src/StandardPayloadBuilder.php
@@ -186,7 +186,7 @@ final class StandardPayloadBuilder implements PayloadBuilder
         }
 
         if ($headers = $this->buildHeaders($message)) {
-            $content['headers'] = $headers;
+            $content['headers'] = (object) $headers;
         }
 
         if ($attachments = $this->buildAttachments($message)) {


### PR DESCRIPTION
This PR addresses an issue with headers content.

> invalid data format\/type","description":"field 'content.headers' is of type 'json_array', but needs to be of type 'json_object'

