### PR TITLE
remove_final

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -10,7 +10,7 @@ namespace SwiftSparkPost;
  * @copyright Future500 B.V.
  * @author    Jasper N. Brouwer <jasper@future500.nl>
  */
-final class Configuration
+class Configuration
 {
     use OptionsSanitizingCapabilities;
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -12,7 +12,7 @@ use Swift_Message;
  * @copyright Future500 B.V.
  * @author    Jasper N. Brouwer <jasper@future500.nl>
  */
-final class Message extends Swift_Message implements ExtendedMessage
+class Message extends Swift_Message implements ExtendedMessage
 {
     use OptionsSanitizingCapabilities;
 

--- a/src/MtRandomNumberGenerator.php
+++ b/src/MtRandomNumberGenerator.php
@@ -10,7 +10,7 @@ namespace SwiftSparkPost;
  * @copyright Future500 B.V.
  * @author    Jasper N. Brouwer <jasper@future500.nl>
  */
-final class MtRandomNumberGenerator implements RandomNumberGenerator
+class MtRandomNumberGenerator implements RandomNumberGenerator
 {
     /**
      * {@inheritdoc}

--- a/src/StandardPayloadBuilder.php
+++ b/src/StandardPayloadBuilder.php
@@ -15,7 +15,7 @@ use Swift_MimePart;
  * @copyright Future500 B.V.
  * @author    Jasper N. Brouwer <jasper@future500.nl>
  */
-final class StandardPayloadBuilder implements PayloadBuilder
+class StandardPayloadBuilder implements PayloadBuilder
 {
     /**
      * @var Configuration

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -23,7 +23,7 @@ use Swift_TransportException;
  * @copyright Future500 B.V.
  * @author    Jasper N. Brouwer <jasper@future500.nl>
  */
-final class Transport implements Swift_Transport
+class Transport implements Swift_Transport
 {
     /**
      * @var Swift_Events_EventDispatcher


### PR DESCRIPTION
I needed to fix a bug (which I may do as a separate pull request), and the final keyword made it much harder than it would have been ordinarily.  There is no reason I see to prevent people from extending your classes.