### PR TITLE
Add transmissionId

### DIFF
--- a/src/ExtendedMessage.php
+++ b/src/ExtendedMessage.php
@@ -15,6 +15,17 @@ use Swift_OutputByteStream;
 interface ExtendedMessage
 {
     /**
+     * @return int
+     */
+    public function getTransmissionId(): int;
+
+    /**
+     * @param int $transmissionId
+     * @return static
+     */
+    public function setTransmissionId(int $transmissionId): ExtendedMessage;
+
+    /**
      * @return string
      */
     public function getCampaignId(): string;

--- a/src/ExtendedMessage.php
+++ b/src/ExtendedMessage.php
@@ -119,5 +119,5 @@ interface ExtendedMessage
      *
      * @return static
      */
-    public function addPart($body, string $contentType = null, string $charset = null);
+    public function addPart($body, $contentType = null, $charset = null);
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -17,6 +17,11 @@ final class Message extends Swift_Message implements ExtendedMessage
     use OptionsSanitizingCapabilities;
 
     /**
+     * @var int
+     */
+    private $transmissionId = 0;
+
+    /**
      * @var string
      */
     private $campaignId;
@@ -73,6 +78,24 @@ final class Message extends Swift_Message implements ExtendedMessage
         $this->substitutionData             = [];
         $this->perRecipientSubstitutionData = [];
         $this->options                      = [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getTransmissionId(): int
+    {
+        return $this->transmissionId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setTransmissionId(int $transmissionId): ExtendedMessage
+    {
+        $this->transmissionId = $transmissionId;
+
+        return $this;
     }
 
     /**

--- a/src/Transport.php
+++ b/src/Transport.php
@@ -125,6 +125,10 @@ final class Transport implements Swift_Transport
             ? (int) $body['results']['total_rejected_recipients']
             : 0;
 
+        if ($message instanceof ExtendedMessage) {
+            $message->setTransmissionId($body['results']['id'] ?? 0);
+        }
+
         if ($event) {
             if ($sent === 0) {
                 $event->setResult(Swift_Events_SendEvent::RESULT_FAILED);

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -158,6 +158,7 @@ final class TransportTest extends TestCase
         $sent = $this->transport->send($message);
 
         $this->assertSame(2, $sent);
+        $this->assertEquals(11668787484950529, $message->getTransmissionId());
     }
 
     /**


### PR DESCRIPTION
This change allows the user to more easily integrate with SparkPost webhooks by making the transmission id available to email senders. Without this there is nothing unique to tie the sent message with the subsequent events.
